### PR TITLE
Updated FindEigen.cmake filename reference.

### DIFF
--- a/eigen.sh
+++ b/eigen.sh
@@ -248,7 +248,7 @@ elif [ "${MODE}" == "generate" ]; then
     echo "Eigen_VERSION.cmake written to ${CMAKE_DIR}"
     # perform specific operations regarding installation
     if [ "${GENERATE_MODE}" == "external" ]; then
-	cp ${SCRIPT_DIR}/Eigen.cmake ${CMAKE_DIR} || fail
+	cp ${SCRIPT_DIR}/FindEigen.cmake ${CMAKE_DIR} || fail
 	echo "Wrote Eigen_VERSION.cmake and Eigen.cmake to ${CMAKE_DIR}"
     elif [ "${GENERATE_MODE}" == "installed" ]; then
 	cp ${SCRIPT_DIR}/FindEigen.cmake ${CMAKE_DIR} || fail


### PR DESCRIPTION
External installations stored Eigen.cmake in the /install/path which triggers cmake to search for EigenConfig.cmake. Replacing filename to FindEigen.cmake resolves.